### PR TITLE
Fixes 'Document instance has no attribute 'file_basename''

### DIFF
--- a/doc2text/__init__.py
+++ b/doc2text/__init__.py
@@ -24,9 +24,9 @@ class Document:
         self.error = None
 
     def read(self, path):
-        filename, self.file_extension = os.path.splitext(path)
-        self.path = path
         self.filename = os.path.basename(path)
+        self.file_basename, self.file_extension = os.path.splitext(self.filename)
+        self.path = path
         self.mime_type = mimetypes.guess_type(path)
         self.file_basepath = os.path.dirname(path)
 


### PR DESCRIPTION
Fixes the following issue

> > > import doc2text
> > > doc = doc2text.Document()
> > > doc.read('image.png')
> > > Traceback (most recent call last):
> > >   File "<stdin>", line 1, in <module>
> > >   File "/usr/local/lib/python2.7/dist-packages/doc2text/**init**.py", line 67, in read
> > >     self.file_basepath, self.file_basename + '_temp.png'
> > > AttributeError: Document instance has no attribute 'file_basename'
