### PR TITLE
Fixed issue with wrong number of variables in function return

### DIFF
--- a/doc2text/page.py
+++ b/doc2text/page.py
@@ -91,7 +91,11 @@ def find_components(im, max_components=16):
     while count > max_components:
         n += 1
         sigma += 0.005
-        contours, hierarchy = cv2.findContours(dilation, cv2.RETR_TREE, cv2.CHAIN_APPROX_SIMPLE)
+        result = cv2.findContours(dilation, cv2.RETR_TREE, cv2.CHAIN_APPROX_SIMPLE)
+        if len(result) == 3:
+            _, contours, hierarchy = result
+        elif len(result) == 2:
+            contours, hierarchy = result
         possible = find_likely_rectangles(contours, sigma)
         count = len(possible)
 

--- a/doc2text/page.py
+++ b/doc2text/page.py
@@ -91,7 +91,7 @@ def find_components(im, max_components=16):
     while count > max_components:
         n += 1
         sigma += 0.005
-        _, contours, hierarchy = cv2.findContours(dilation, cv2.RETR_TREE, cv2.CHAIN_APPROX_SIMPLE)
+        contours, hierarchy = cv2.findContours(dilation, cv2.RETR_TREE, cv2.CHAIN_APPROX_SIMPLE)
         possible = find_likely_rectangles(contours, sigma)
         count = len(possible)
 

--- a/doc2text/page.py
+++ b/doc2text/page.py
@@ -7,6 +7,8 @@ from scipy.ndimage.filters import rank_filter
 from scipy import stats
 import pytesseract
 import os
+import traceback
+import sys
 
 class Page:
     def __init__(self, im, page_num):
@@ -22,6 +24,10 @@ class Page:
             self.crop_shape = self.image.shape
             return self.image
         except Exception as e:
+            for frame in traceback.extract_tb(sys.exc_info()[2]):
+                fname,lineno,fn,text = frame
+                print "Error in %s on line %d" % (fname, lineno)
+                print e
             self.err = e
             self.healthy = False
 


### PR DESCRIPTION
`_, contours, hierarchy = cv2.findContours(dilation, cv2.RETR_TREE, cv2.CHAIN_APPROX_SIMPLE)`
This ^ actually returns two arguments instead of three for me. Version differences?
And please do not treat exceptions like you do - it was very hard to find out what happened 
because of crop() silently excepted without any signs, though leaving self.image unset, which lead to error in deskew() 'Page does not have member 'image''
Btw I managed to run the app after this commit
