### PR TITLE
Compile opencv in /tmp

### DIFF
--- a/install_deps.sh
+++ b/install_deps.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 # Install OpenCV
+cd /tmp
 sudo apt-get install -y build-essential
 sudo apt-get install -y cmake git libgtk2.0-dev pkg-config libavcodec-dev libavformat-dev libswscale-dev
 sudo apt-get install -y python-dev python-numpy libtbb2 libtbb-dev libjpeg-dev libpng-dev libtiff-dev libjasper-dev libdc1394-22-dev


### PR DESCRIPTION
It avoids having opencv and opencv_contrib in working directory after installation. /tmp dir is cleared at boot time, but maybe we also want to manually remove the folders after installation.

Also, FYI your installation script also work with Ubuntu 14.04
