### PR TITLE
Fix setup.cfg field: replace description-file with description_file for setuptools 0.78+

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,4 +5,4 @@
 universal=1
 
 [metadata]
-description-file = README.rst
+description_file = README.rst


### PR DESCRIPTION
Setuptools 0.78+ no longer supports hyphens in setup.cfg keys.
This PR updates description-file to description_file to ensure compatibility with newer versions of setuptools.